### PR TITLE
プレイヤー加速/ダッシュ機能・乗っ取り判定機能の実装

### DIFF
--- a/Assets/Characters/Player/Scripts/JoystickMove.cs
+++ b/Assets/Characters/Player/Scripts/JoystickMove.cs
@@ -1,12 +1,13 @@
 using System.Collections;
 using System.Collections.Generic;
+using Unity.VisualScripting;
 using UnityEngine;
 
 public class JoystickMove : MonoBehaviour
 {
     public float acceleration = 5f; // 加速力
-    public float maxSpeed = 10f;    // 最大速度
-    public float turnSpeed = 10f;   // 旋回速度（値が大きいほどキビキビ曲がる）
+    public float maxSpeed = 10f; // 最大速度
+    public float turnSpeed = 10f; // 旋回速度（値が大きいほどキビキビ曲がる）
 
     public float dashMultiplier = 1.5f;
 
@@ -31,8 +32,7 @@ public class JoystickMove : MonoBehaviour
             float currentSpeed = rb.velocity.magnitude;
 
             // 3. 速度の「大きさ」だけを計算（方向転換中でも加速させる）
-            //    現在の速度に加速分を足す。ただし0からスタートする場合も考慮して最低限の初速を与えるか、
-            //    シンプルに現在の速度+加速で計算する
+            //    現在の速度に加速分を足す。accelerationは1秒あたりの速度増加量（線形加速）
             float nextSpeed = Mathf.Min(currentSpeed + acceleration * Time.fixedDeltaTime, maxSpeed);
 
             // もし停止状態からなら、最低限の動き出し速度を保証（オプション）
@@ -77,6 +77,7 @@ public class JoystickMove : MonoBehaviour
                 dashDuration = defaultDashDuration;
                 isMaxSpeed = false;
                 rb.drag = 7.5f;
+                rb.angularDrag = 7.5f;
             }
         }
     }
@@ -85,5 +86,11 @@ public class JoystickMove : MonoBehaviour
     {
         Vector2 direction = new Vector2(dynamicJoystick.Horizontal, dynamicJoystick.Vertical);
         return direction.normalized;
+    }
+
+    public void OnCollisionEnter2D(Collision2D collision){
+        if(collision.gameObject.tag == "Enemy" && isMaxSpeed&&dashDuration>0){
+            Debug.Log("ダッシュ状態でEnemyに衝突した");
+        }
     }
 }

--- a/Assets/Characters/Player/Scripts/JoystickMove.cs
+++ b/Assets/Characters/Player/Scripts/JoystickMove.cs
@@ -3,6 +3,14 @@ using System.Collections.Generic;
 using Unity.VisualScripting;
 using UnityEngine;
 
+public enum PlayerMoveState
+{
+    Idle,           // 停止中
+    Accelerating,   // 加速中（最高速度未到達）
+    MaxSpeed,       // 最高速度到達（入力あり）
+    Dashing         // 突進中（入力なし、最高速度維持）
+}
+
 public class JoystickMove : MonoBehaviour
 {
     public float acceleration = 5f; // 加速力
@@ -11,7 +19,8 @@ public class JoystickMove : MonoBehaviour
 
     public float dashMultiplier = 1.5f;
 
-    private bool isMaxSpeed = false;
+    private PlayerMoveState currentState = PlayerMoveState.Idle;
+    private PlayerMoveState previousState = PlayerMoveState.Idle;
     private float defaultDashDuration = 0.2f;
     private float dashDuration = 0f;
     public DynamicJoystick dynamicJoystick;
@@ -20,66 +29,170 @@ public class JoystickMove : MonoBehaviour
     void FixedUpdate()
     {
         Vector2 input = new Vector2(dynamicJoystick.Horizontal, dynamicJoystick.Vertical);
+        bool hasInput = input.sqrMagnitude > 0.01f;
 
-        if (input.sqrMagnitude > 0.01f)
+        // 状態遷移の処理
+        UpdateState(hasInput);
+
+        // 状態に応じた処理
+        switch (currentState)
         {
-            rb.drag = 0.5f;
+            case PlayerMoveState.Idle:
+                HandleIdle();
+                break;
 
-            // 1. 入力方向（行きたい方向）
-            Vector2 targetDir = input.normalized;
+            case PlayerMoveState.Accelerating:
+                HandleAccelerating(input);
+                break;
 
-            // 2. 現在の速度（大きさ）を取得
-            float currentSpeed = rb.velocity.magnitude;
+            case PlayerMoveState.MaxSpeed:
+                HandleMaxSpeed(input);
+                break;
 
-            // 3. 速度の「大きさ」だけを計算（方向転換中でも加速させる）
-            //    現在の速度に加速分を足す。accelerationは1秒あたりの速度増加量（線形加速）
-            float nextSpeed = Mathf.Min(currentSpeed + acceleration * Time.fixedDeltaTime, maxSpeed);
-
-            // もし停止状態からなら、最低限の動き出し速度を保証（オプション）
-            if (nextSpeed < 1f) nextSpeed = 1f;
-
-            // 4. 「向き」だけを滑らかに変える
-            //    LerpではなくRotateTowardsを使うことで、ベクトルの長さを保ったまま回転させる
-            //    Vector2はVector3として扱えるため、Vector3.RotateTowardsを使用
-            Vector2 currentDir = rb.velocity.normalized;
-            if (currentDir == Vector2.zero) currentDir = targetDir; // 停止時は入力方向を現在地とする
-
-            Vector2 newDir = Vector3.RotateTowards(currentDir, targetDir, turnSpeed * Time.fixedDeltaTime, 0f);
-            newDir.Normalize(); // 念のため正規化
-
-            // 5. 新しい向き × 計算した速度 を適用
-            rb.velocity = newDir * nextSpeed;
-
-            // 6. 見た目（画像の回転）
-            float angle = Mathf.Atan2(newDir.y, newDir.x) * Mathf.Rad2Deg - 90f;
-            transform.rotation = Quaternion.RotateTowards(
-                transform.rotation,
-                Quaternion.Euler(0, 0, angle),
-                720 * Time.deltaTime
-            );
-            if (nextSpeed >= maxSpeed)
-            {
-                isMaxSpeed = true;
-                dashDuration = defaultDashDuration;
-                Debug.Log("最高速度に到達");
-
-            }
+            case PlayerMoveState.Dashing:
+                HandleDashing();
+                break;
         }
-        else
+    }
+
+    private void UpdateState(bool hasInput)
+    {
+        previousState = currentState;
+
+        switch (currentState)
         {
-            if (isMaxSpeed&&dashDuration>0)
-            {
-            
-                rb.velocity = rb.velocity.normalized * maxSpeed* dashMultiplier;
-                dashDuration-=Time.fixedDeltaTime;
-            }
-            else{
-                dashDuration = defaultDashDuration;
-                isMaxSpeed = false;
-                rb.drag = 7.5f;
-                rb.angularDrag = 7.5f;
-            }
+            case PlayerMoveState.Idle:
+                if (hasInput)
+                {
+                    currentState = PlayerMoveState.Accelerating;
+                }
+                break;
+
+            case PlayerMoveState.Accelerating:
+                if (!hasInput)
+                {
+                    currentState = PlayerMoveState.Idle;
+                }
+                break;
+
+            case PlayerMoveState.MaxSpeed:
+                if (!hasInput)
+                {
+                    currentState = PlayerMoveState.Dashing;
+                }
+                break;
+
+            case PlayerMoveState.Dashing:
+                dashDuration -= Time.fixedDeltaTime;
+                if (dashDuration <= 0)
+                {
+                    currentState = PlayerMoveState.Idle;
+                }
+                // 突進中は操作不能のため、入力による状態遷移を無視
+                break;
         }
+
+        // 状態が変わったときにログを出力
+        if (previousState != currentState)
+        {
+            Debug.Log($"状態遷移: {previousState} -> {currentState}");
+        }
+    }
+
+    private void HandleIdle()
+    {
+        rb.drag = 7.5f;
+        rb.angularDrag = 7.5f;
+    }
+
+    private void HandleAccelerating(Vector2 input)
+    {
+        rb.drag = 0.5f;
+
+        // 1. 入力方向（行きたい方向）
+        Vector2 targetDir = input.normalized;
+
+        // 2. 現在の速度（大きさ）を取得
+        float currentSpeed = rb.velocity.magnitude;
+
+        // 3. 速度の「大きさ」だけを計算（方向転換中でも加速させる）
+        //    現在の速度に加速分を足す。accelerationは1秒あたりの速度増加量（線形加速）
+        float nextSpeed = Mathf.Min(currentSpeed + acceleration * Time.fixedDeltaTime, maxSpeed);
+
+        // もし停止状態からなら、最低限の動き出し速度を保証（オプション）
+        if (nextSpeed < 1f) nextSpeed = 1f;
+
+        // 4. 「向き」だけを滑らかに変える
+        //    LerpではなくRotateTowardsを使うことで、ベクトルの長さを保ったまま回転させる
+        //    Vector2はVector3として扱えるため、Vector3.RotateTowardsを使用
+        Vector2 currentDir = rb.velocity.normalized;
+        if (currentDir == Vector2.zero) currentDir = targetDir; // 停止時は入力方向を現在地とする
+
+        Vector2 newDir = Vector3.RotateTowards(currentDir, targetDir, turnSpeed * Time.fixedDeltaTime, 0f);
+        newDir.Normalize(); // 念のため正規化
+
+        // 5. 新しい向き × 計算した速度 を適用
+        rb.velocity = newDir * nextSpeed;
+
+        // 6. 見た目（画像の回転）
+        UpdateRotation(newDir);
+
+        // 最高速度到達チェック
+        if (nextSpeed >= maxSpeed)
+        {
+            previousState = currentState;
+            currentState = PlayerMoveState.MaxSpeed;
+            dashDuration = defaultDashDuration;
+            Debug.Log($"状態遷移: {previousState} -> {currentState} (最高速度に到達)");
+        }
+    }
+
+    private void HandleMaxSpeed(Vector2 input)
+    {
+        rb.drag = 0.5f;
+
+        // 1. 入力方向（行きたい方向）
+        Vector2 targetDir = input.normalized;
+
+        // 2. 現在の速度（大きさ）を取得
+        float currentSpeed = rb.velocity.magnitude;
+
+        // 3. 最高速度を維持
+        float nextSpeed = maxSpeed;
+
+        // 4. 「向き」だけを滑らかに変える
+        Vector2 currentDir = rb.velocity.normalized;
+        if (currentDir == Vector2.zero) currentDir = targetDir;
+
+        Vector2 newDir = Vector3.RotateTowards(currentDir, targetDir, turnSpeed * Time.fixedDeltaTime, 0f);
+        newDir.Normalize();
+
+        // 5. 新しい向き × 最高速度 を適用
+        rb.velocity = newDir * nextSpeed;
+
+        // 6. 見た目（画像の回転）
+        UpdateRotation(newDir);
+    }
+
+    private void HandleDashing()
+    {
+        rb.drag = 0.5f;
+
+        // 突進中は最高速度を維持
+        if (rb.velocity.magnitude > 0.01f)
+        {
+            rb.velocity = rb.velocity.normalized * maxSpeed * dashMultiplier;
+        }
+    }
+
+    private void UpdateRotation(Vector2 direction)
+    {
+        float angle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg - 90f;
+        transform.rotation = Quaternion.RotateTowards(
+            transform.rotation,
+            Quaternion.Euler(0, 0, angle),
+            720 * Time.deltaTime
+        );
     }
 
     public Vector2 GetJoystickInput(DynamicJoystick dynamicJoystick)
@@ -88,8 +201,10 @@ public class JoystickMove : MonoBehaviour
         return direction.normalized;
     }
 
-    public void OnCollisionEnter2D(Collision2D collision){
-        if(collision.gameObject.tag == "Enemy" && isMaxSpeed&&dashDuration>0){
+    public void OnCollisionEnter2D(Collision2D collision)
+    {
+        if (collision.gameObject.tag == "Enemy" && currentState == PlayerMoveState.Dashing)
+        {
             Debug.Log("ダッシュ状態でEnemyに衝突した");
         }
     }

--- a/Assets/Scenes/PlayerControllerScene.unity
+++ b/Assets/Scenes/PlayerControllerScene.unity
@@ -132,8 +132,9 @@ GameObject:
   m_Component:
   - component: {fileID: 152552185}
   - component: {fileID: 152552184}
-  - component: {fileID: 152552186}
   - component: {fileID: 152552187}
+  - component: {fileID: 152552188}
+  - component: {fileID: 152552189}
   m_Layer: 0
   m_Name: Player_temp
   m_TagString: Untagged
@@ -209,22 +210,6 @@ Transform:
   - {fileID: 362663582}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &152552186
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 152552183}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d442ca9367c3e40d5a9e314afd30c43b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  speed: 10
-  maxSpeed: 10
-  dynamicJoystick: {fileID: 162252394}
-  rb: {fileID: 152552187}
 --- !u!50 &152552187
 Rigidbody2D:
   serializedVersion: 4
@@ -252,6 +237,59 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!58 &152552188
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 152552183}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.5
+--- !u!114 &152552189
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 152552183}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d442ca9367c3e40d5a9e314afd30c43b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  acceleration: 10
+  maxSpeed: 10
+  turnSpeed: 10
+  dashMultiplier: 1.5
+  dynamicJoystick: {fileID: 162252394}
+  rb: {fileID: 152552187}
 --- !u!224 &162252393 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 8135886326569738822, guid: 56fae09712773584fb63896d473a98ee, type: 3}
@@ -659,6 +697,136 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1049286268
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1049286270}
+  - component: {fileID: 1049286269}
+  - component: {fileID: 1049286271}
+  m_Layer: 0
+  m_Name: Enemy_temp
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1049286269
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1049286268}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1049286270
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1049286268}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 6.15, y: 3.68, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1049286271
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1049286268}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1001 &1680141160
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -764,3 +932,4 @@ SceneRoots:
   - {fileID: 152552185}
   - {fileID: 578466646}
   - {fileID: 994893578}
+  - {fileID: 1049286270}

--- a/Assets/Scenes/PlayerControllerScene.unity
+++ b/Assets/Scenes/PlayerControllerScene.unity
@@ -221,7 +221,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d442ca9367c3e40d5a9e314afd30c43b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 2
+  speed: 10
+  maxSpeed: 10
   dynamicJoystick: {fileID: 162252394}
   rb: {fileID: 152552187}
 --- !u!50 &152552187

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Enemy
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## 加速処理
AddForceだとジョイスティック入力を逆にした時（上から下とか）に力が相殺して減速してしまうので、rb.velocityを直接操作する形にしました。
accelerationは加速率（一定）、maxSpeedは最高速度です。

## 状態管理
-`PlayerMoveState`で Idle(停止中)、Accelerating(加速中)、MaxSpeed(最高速度、乗っ取り可能)、Dashing(ダッシュ中、操作不能) の状態管理を実装。
- 状態が変わるとdebug.logが出ます

## その他
- テスト用に新しい ‎`Enemy_temp` GameObject を追加し、SpriteRenderer、BoxCollider2D、タグ “Enemy” を設定してプレイヤー—敵の相互作用を検証。